### PR TITLE
Display number of books in a shelf.

### DIFF
--- a/src/gr-progress/includes/Shelf.php
+++ b/src/gr-progress/includes/Shelf.php
@@ -37,6 +37,9 @@ class Shelf {
         if ($xml === false) {
             return;
         }
+        
+        $reviews = $xml->find("reviews", 0);
+        $this->books_total = $reviews->total;
 
         foreach ($xml->find("review") as $reviewElement) {
             $rating = $reviewElement->find("rating", 0)->plaintext;
@@ -111,10 +114,14 @@ class Shelf {
         if ($xml === false) {
             return;
         }
+        
+        // We want to know how many books a shelf contains in total, regardless of how many books are returned by our query.
+        $reviews = $xml->find("reviews", 0);
+        $this->books_total = $reviews->total;
 
         foreach ($xml->find("item") as $item) {
             $bookID = $item->find("book_id", 0)->plaintext;
-            $srcWithCDATA = $item->find("book_large_image_url", 0)->plaintext;
+            $srcWithCDATA = $item->find("book_small_image_url", 0)->plaintext;
             $src = preg_replace('/^\s*(?:\/\/)?<!\[CDATA\[([\s\S]*)(?:\/\/)?\]\]>\s*\z/', '$1', $srcWithCDATA);
             $src = preg_replace('/^https?:/', '', $src);  // remove http: or https: to use the same protocol as the page
             if (array_key_exists($bookID, $this->books)) {
@@ -139,6 +146,10 @@ class Shelf {
 
     public function getBooks() {
         return $this->books;
+    }
+
+    public function getBooksTotal() {
+        return $this->books_total;
     }
 
     public function updateProgress() {

--- a/src/gr-progress/includes/Shelf.php
+++ b/src/gr-progress/includes/Shelf.php
@@ -119,6 +119,8 @@ class Shelf {
         $reviews = $xml->find("reviews", 0);
         $this->books_total = $reviews->total;
 
+        // Goodreads return three image sizes, book_small_image_url, book_medium_image_url and book_large_image_url.
+        // This could be an option?
         foreach ($xml->find("item") as $item) {
             $bookID = $item->find("book_id", 0)->plaintext;
             $srcWithCDATA = $item->find("book_small_image_url", 0)->plaintext;

--- a/src/gr-progress/includes/gr_progress_cvdm_backend.php
+++ b/src/gr-progress/includes/gr_progress_cvdm_backend.php
@@ -145,8 +145,8 @@ class gr_progress_cvdm_backend {
     private function getWidgetHTML($args) {
         ob_start();
         $this->printWidgetBoilerplateStart($args);
-        $this->printGoodreadsAttribution();
         $this->printShelf();
+        $this->printGoodreadsAttribution();
         $this->printWidgetBoilerplateEnd($args);
         return ob_get_clean();
     }
@@ -169,7 +169,14 @@ class gr_progress_cvdm_backend {
     }
 
     private function printGoodreadsAttribution() {
-        echo "<p class='goodreads-attribution'>{$this->widgetData['goodreadsAttribution']}</p>";
+        // If the attribution text was changed by the user, replace #books_total by $this->shelf->books_total.
+        // Could be changed to check not for change in general, but for existance of "#books_total" - search might be more costly than complete string comparison.
+        if ($this->widgetData['goodreadsAttribution'] !== $this->DEFAULT_SETTINGS['goodreadsAttribution']) {
+            $attribution = str_replace('#books_total', $this->shelf->books_total, $this->widgetData['goodreadsAttribution']);
+            echo "<p class='goodreads-attribution'>$attribution</p>";
+        } else {
+            echo "<p class='goodreads-attribution'>{$this->widgetData['goodreadsAttribution']}</p>";
+        }
     }
 
     private function printShelf() {


### PR DESCRIPTION
* Added $this->books_total - carrying the total number of books in the current shelf.
* Modified outout order, so that the attribution lines is displayed after the books.
* Modified output of the attribution line to replace placeholder "#books_total" by $this->books_total.
* Modifed covers handling, use book_small_image_url instead of book_large_image_url.